### PR TITLE
feat(1): add hasDeliveryNotes and documentType to SubmitPayload 

### DIFF
--- a/src/modules/analyze/analyze.service.ts
+++ b/src/modules/analyze/analyze.service.ts
@@ -11,7 +11,8 @@ interface SubmitPayload {
   buffer: string;
   filename: string;
   mimetype: string;
-  notes?: string;
+  hasDeliveryNotes: boolean;
+  documentType: string;
   enterpriseId?: string;
   uploadedBy: string;
 }
@@ -51,7 +52,8 @@ export class AnalyzeService {
       buffer: file.buffer.toString('base64'),
       filename: file.originalname,
       mimetype: file.mimetype,
-      notes: body.notes,
+      hasDeliveryNotes: body.hasDeliveryNotes,
+      documentType: body.documentType,
       enterpriseId: user.enterpriseId,
       uploadedBy: user.userId,
     };

--- a/src/modules/analyze/dto/submit-invoice.dto.ts
+++ b/src/modules/analyze/dto/submit-invoice.dto.ts
@@ -1,8 +1,11 @@
-import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsString } from 'class-validator';
 
 export class SubmitInvoiceDto {
-  @IsOptional()
   @IsString()
-  @MaxLength(500)
-  notes?: string;
+  documentType!: string;
+
+  @Transform(({ value }) => value === 'true' || value === true)
+  @IsBoolean()
+  hasDeliveryNotes!: boolean;
 }


### PR DESCRIPTION
This pull request updates the payload structure and DTO validation for the invoice analysis feature, primarily to replace the optional `notes` field with two new required fields: `hasDeliveryNotes` (a boolean) and `documentType` (a string). These changes ensure more explicit and structured data handling for invoice submissions.

Payload structure changes:

* Replaced the optional `notes` field in the `SubmitPayload` interface with two new required fields: `hasDeliveryNotes` (boolean) and `documentType` (string). (`src/modules/analyze/analyze.service.ts`)
* Updated the construction of the payload in the `AnalyzeService` to use `hasDeliveryNotes` and `documentType` from the request body instead of `notes`. (`src/modules/analyze/analyze.service.ts`)

DTO validation updates:

* Modified `SubmitInvoiceDto` to remove `notes` and add `documentType` (string) and `hasDeliveryNotes` (boolean, with transformation and validation). (`src/modules/analyze/dto/submit-invoice.dto.ts`)